### PR TITLE
More generic approach to remove unused GPU packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,8 +47,8 @@ parts:
       # Remove GPU-specific pytorch and its dependencies
       pip install pip-autoremove
       pip-autoremove torch -y
-      rm -rf $CRAFT_PART_INSTALL/lib/python3.12/site-packages/nvidia
-      rm -rf $CRAFT_PART_INSTALL/lib/python3.12/site-packages/torch
+      rm -rf $CRAFT_PART_INSTALL/lib/python*/site-packages/nvidia
+      rm -rf $CRAFT_PART_INSTALL/lib/python*/site-packages/torch
       
       # Install CPU-only pytorch
       pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,14 +45,11 @@ parts:
       craftctl default
       
       # Remove GPU-specific pytorch and its dependencies
-      pip uninstall -y \
-        torch triton \
-        cuda-bindings cuda-pathfinder \
-        nvidia-cublas-cu12 nvidia-cuda-cupti-cu12 nvidia-cuda-nvrtc-cu12 \
-        nvidia-cuda-runtime-cu12 nvidia-cudnn-cu12 nvidia-cufft-cu12 \
-        nvidia_cufile_cu12 nvidia-curand-cu12 nvidia-cusolver-cu12 \
-        nvidia-cusparse-cu12 nvidia-cusparselt-cu12 nvidia-nccl-cu12 \
-        nvidia-nvjitlink-cu12 nvidia-nvshmem-cu12 nvidia-nvtx-cu12
+      pip install pip-autoremove
+      pip-autoremove torch -y
+      rm -rf $CRAFT_PART_INSTALL/lib/python3.12/site-packages/nvidia
+      rm -rf $CRAFT_PART_INSTALL/lib/python3.12/site-packages/torch
+      
       # Install CPU-only pytorch
       pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
     


### PR DESCRIPTION
With a recent update of Open WebUI and PyTorch, they updated the nvidia dependencies, changing the names. Our manual list of packages to remove does not exist, and these unused GPU libraries are not removed.

This PR instead makes use of pip-autoremove, as well as manually deleting the unused torch and nvidia packages before installing the cpu-only torch.

This change decreases the snap size to 844MiB.

Test on amd64:
- [x] Snap installs correctly
- [x] Server logs does not show a crash
- [x] After installation UI can be accessed on http://localhost:8080/
- [x] UI asks to create a new admin account
- [x] Release notes are shown and indicates v0.8.x
- [x] Add local inference snap as an OpenAI endpoint
- [x] Use dictate mode
- [x] Prompt model with text
- [x] Read out response aloud
- [x] Use Voice Mode
- [x] Prompt model with an image
- [x] Prompt with PDF