### PR TITLE
Stage RAG model

### DIFF
--- a/scripts/run-server.sh
+++ b/scripts/run-server.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
+
 set -e
+
 HOST=$(snapctl get host)
 PORT=$(snapctl get port)
+
 exec open-webui serve --host "$HOST" --port "$PORT" "$@"

--- a/scripts/run-server.sh
+++ b/scripts/run-server.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-
 set -e
-
 HOST=$(snapctl get host)
 PORT=$(snapctl get port)
-
 exec open-webui serve --host "$HOST" --port "$PORT" "$@"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -3,3 +3,18 @@ set -e
 
 snapctl set host="127.0.0.1"
 snapctl set port="8080"
+
+# Seed the writable huggingface cache with the RAG embedding model that was
+# bundled into the snap at build time, so it does not have to be downloaded
+# from huggingface.co on first startup. This only happens on initial install;
+# afterwards the model lives in writable storage and can be updated by Open
+# WebUI.
+HF_HUB_CACHE="${HF_HUB_CACHE:-$SNAP_COMMON/cache/huggingface/hub}"
+SEED_DIR="$SNAP/embedding-models"
+MODEL_DIR="models--sentence-transformers--all-MiniLM-L6-v2"
+
+if [ -d "$SEED_DIR/$MODEL_DIR" ]; then
+  mkdir -p "$HF_HUB_CACHE"
+  cp -a "$SEED_DIR/$MODEL_DIR" "$HF_HUB_CACHE/"
+fi
+

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,13 +1,9 @@
 #!/bin/bash
 set -e
 
-snapctl set host="127.0.0.1"
-snapctl set port="8080"
-
-# Seed the writable huggingface cache with the RAG embedding model that was
-# bundled into the snap at build time, so it does not have to be downloaded
-# from huggingface.co on first startup. The same copy is performed by the
-# post-refresh hook so that a new snap revision can deploy an updated model.
+# Refresh the writable huggingface cache with the RAG embedding model that was
+# bundled into the (new) snap revision, so that upgrading the snap can deploy
+# an updated model. This mirrors the copy performed by the install hook.
 HF_HUB_CACHE="${HF_HUB_CACHE:-$SNAP_COMMON/cache/huggingface/hub}"
 SEED_DIR="$SNAP/embedding-models"
 MODEL_DIR="models--sentence-transformers--all-MiniLM-L6-v2"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,7 +59,15 @@ parts:
       
       # Install CPU-only pytorch
       pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-    
+
+      # Pre-download the default RAG embedding model
+      # (sentence-transformers/all-MiniLM-L6-v2) into the snap so that it does
+      # not have to be fetched from huggingface.co on first startup.
+      # Only the files required to load the model with the safetensors backend
+      # are downloaded to keep the snap size down. The resulting cache uses the
+      # standard huggingface_hub layout so Open WebUI resolves it offline.
+      HF_HUB_DISABLE_PROGRESS_BARS=1 python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='sentence-transformers/all-MiniLM-L6-v2', cache_dir='$CRAFT_PART_INSTALL/embedding-models', allow_patterns=['*.json', '*.txt', 'model.safetensors'])"
+
   version:
     after:
       - open-webui
@@ -105,6 +113,12 @@ apps:
       DATA_DIR: $SNAP_COMMON/data
       STATIC_DIR: $SNAP_DATA/static
       ENABLE_VERSION_UPDATE_CHECK: "false"
+      # huggingface_hub cache directory. It must be writable so the bundled
+      # model can be copied here on install (see the install hook) and so Open
+      # WebUI can update it or download other models at runtime. Open WebUI's
+      # get_model_path() leaves snapshot_download's cache_dir unset, so it
+      # falls back to HF_HUB_CACHE.
+      HF_HUB_CACHE: $SNAP_COMMON/cache/huggingface/hub
 
   import-shared-configs:
     command: bin/import-shared-configs.py

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -113,12 +113,8 @@ apps:
       DATA_DIR: $SNAP_COMMON/data
       STATIC_DIR: $SNAP_DATA/static
       ENABLE_VERSION_UPDATE_CHECK: "false"
-      # huggingface_hub cache directory. It must be writable so the bundled
-      # model can be copied here on install (see the install hook) and so Open
-      # WebUI can update it or download other models at runtime. Open WebUI's
-      # get_model_path() leaves snapshot_download's cache_dir unset, so it
-      # falls back to HF_HUB_CACHE.
       HF_HUB_CACHE: $SNAP_COMMON/cache/huggingface/hub
+      RAG_EMBEDDING_MODEL_AUTO_UPDATE: "false"
 
   import-shared-configs:
     command: bin/import-shared-configs.py


### PR DESCRIPTION
This PR stages the RAG model during build time. Auto updates of this model are also disabled. This is to prevent the service from connecting to Huggingface at startup to check if the available model is outdated. The assumption would be that we ship the latest version available in the latest available version of the snap.

At install time and after a refresh, the read only model inside the snap is copied to a writable directory in $SNAP_COMMON. This allows the user and the Open WebUI service to download additional RAG models during runtime. They could also re-download the staged model, and override the copy in $SNAP_COMMON without running into read only filesystem issues. 

The drawback of this approach is that the default RAG model will take twice the amount of disk space. One copy in the snap squashfs file and one copy in $SNAP_COMMON.

Related:
* Resolves https://github.com/canonical/open-webui-snap/issues/36