### PR TITLE
Refactor dependency removal for PyTorch in snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,8 +52,8 @@ parts:
       craftctl default
       
       # Remove GPU-specific pytorch and its dependencies
-      pip install pip-autoremove
-      pip-autoremove torch -y
+      pip list --format=freeze | grep -iE '^(nvidia|cuda|triton)' | cut -d= -f1 | xargs -r pip uninstall -y
+      pip uninstall -y torch
       rm -rf $CRAFT_PART_INSTALL/lib/python*/site-packages/nvidia
       rm -rf $CRAFT_PART_INSTALL/lib/python*/site-packages/torch
       


### PR DESCRIPTION
Python's setup tools got updated from v82 to v83, dropping support for the legacy API used by pip-autoremove. The same workflow run that succeeded on 29 June, failed when it was retried on 9 July. This is caused by dependencies not being pinned.

> The python plugin in snapcraft automatically installs pip, setuptools, and wheel into the build environment as part of its standard setup. This is built-in plugin behavior, not something configured in this project.

> The setuptools Update: The module pkg_resources was historically bundled with the setuptools package. In your [successful run on June 29](https://github.com/canonical/open-webui-snap/actions/runs/28355576839/attempts/1), the environment downloaded and installed setuptools-82.0.1. By the time the [failed run executed on July 9](https://github.com/canonical/open-webui-snap/actions/runs/28355576839), the environment pulled down the newer setuptools-83.0.0.

> The Warning Signs: The successful log actually predicted this failure. During the successful execution of pip-autoremove, Python threw an explicit warning stating that pkg_resources is deprecated as an API, is slated for removal, and advises users to either refrain from using the package or explicitly pin Setuptools<81. The update to version 83.0.0 ultimately removed or broke this legacy API access, causing pip-autoremove to crash entirely.

This PR replaces `pip-autoremove` by standard `pip`. It lists all nvidia, cuda and triton packages, removes them, then removes pytorch, before installing pytorch-cpu.